### PR TITLE
Do not export configs for formats that do not support it

### DIFF
--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -890,6 +890,10 @@ def load_config(args):
     if args.dir is not None and len(args.dir) > 0:
         config['output_dir'] = args.dir
 
+    # Do not export configs for formats that do not support it
+    if config['output_format'] in ['graphite', 'd2']:
+        config['export_configs'] = False
+
     return config
 
 def main():


### PR DESCRIPTION
No need to export configs if the output format is for visualization: graphite, d2