### PR TITLE
Support for user-provided output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following software versions were tested for compatibility with `nrx`:
 
 # Prerequisites
 
-* Python 3.9+. In the commands below we assume use have `python3.9` executable. If you have a different name, change accordingly.
+* Python 3.9+. In the commands below we assume you have `python3.9` executable. If it is under a different name, change accordingly.
 * PIP
 
     ```Shell
@@ -176,7 +176,13 @@ Use `--config <filename>` argument to specify a configuration file to use. The s
 
 # Templates
 
-**nrx** renders all topology artifacts from [Jinja2](https://jinja.palletsprojects.com/en/3.1.x/) templates. Depending on the desired output format, the required templates are taken from a matching subfolder. For example, if the output format is `clab` for Containerlab, then templates are searched under `clab` subfolder. For Cisco Modelling Labs `cml` format the subfolder would be `cml`. A user can create their own templates for any output format and store them in a subfolder with a format name they would use for `--output` argument.
+**nrx** renders all topology artifacts from [Jinja2](https://jinja.palletsprojects.com/en/3.1.x/) templates the user points `nrx` to using `--templates` parameter.
+
+By default, **nrx** searches for the template files in the current directory. You can provide a list of folders to search for the templates via `TEMPLATES_PATH` parameter in the [configuration file](#configuration-file), or use `--templates` argument.
+
+Depending on the desired output format, the required templates are taken from a matching subfolder. For example, if the output format is `clab` for Containerlab, then templates are taken from `clab` subfolder. For Cisco Modelling Labs `cml` format the subfolder would be `cml`.
+
+A user can create their own templates for any output format and store them in a subfolder with a format name they would use for `--output` argument. To make the new output format available to `nrx`, an entry describing basic properties of the format must be added to [`formats.yaml`](./templates/formats.yaml) file in the `templates` folder.
 
 Most templates are unique for each node `kind`. Value of `kind` is taken from NetBox `device.platform.slug` field. The full list of template search rules:
 
@@ -186,8 +192,6 @@ Most templates are unique for each node `kind`. Value of `kind` is taken from Ne
 * `<format>/interface_maps/<kind>.j2`: templates for mappings between real interface names and emulated interface names used by this NOS `kind`. Optional, as not all `kinds` support such mappings.
 
 This repository includes a set of [netreplica/templates](https://github.com/netreplica/templates) as a submodule. See more details about available templates in the [templates/README.md](https://github.com/netreplica/templates).
-
-By default, **nrx** searches for the template files in the current directory. You can provide a list of folders to search for the templates via `TEMPLATES_PATH` parameter in the [configuration file](#configuration-file), or use `--templates` argument.
 
 # How to use
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ optional arguments:
   -h, --help                show this help message and exit
   -c, --config CONFIG       configuration file
   -i, --input INPUT         input source: netbox (default) | cyjs
-  -o, --output OUTPUT       output format: cyjs | gml | clab | cml | graphite | d2
+  -o, --output OUTPUT       output format: cyjs for JSON, or any other format supported by provided templates
   -a, --api API             netbox API URL
   -s, --site SITE           netbox site to export
   -t, --tags TAGS           netbox tags to export, for multiple tags use a comma-separated list: tag1,tag2,tag3 (uses AND logic)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ By default, **nrx** searches for the template files in the current directory. Yo
 
 Depending on the desired output format, the required templates are taken from a matching subfolder. For example, if the output format is `clab` for Containerlab, then templates are taken from `clab` subfolder. For Cisco Modelling Labs `cml` format the subfolder would be `cml`.
 
-A user can create their own templates for any output format and store them in a subfolder with a format name they would use for `--output` argument. To make the new output format available to `nrx`, an entry describing basic properties of the format must be added to [`formats.yaml`](./templates/formats.yaml) file in the `templates` folder.
+A user can create their own templates for any output format and store them in a subfolder with a format name they would use for `--output` argument. To make the new output format available to **nrx**, an entry describing basic properties of the format must be added to [`formats.yaml`](templates/formats.yaml) file in the `templates` folder.
 
 Most templates are unique for each node `kind`. Value of `kind` is taken from NetBox `device.platform.slug` field. The full list of template search rules:
 

--- a/README.md
+++ b/README.md
@@ -169,12 +169,12 @@ Use `--config <filename>` argument to specify a configuration file to use. The s
 
 **nrx** renders all topology artifacts from [Jinja2](https://jinja.palletsprojects.com/en/3.1.x/) templates. Depending on the desired output format, the required templates are taken from a matching subfolder. For example, if the output format is `clab` for Containerlab, then templates are searched under `clab` subfolder. For Cisco Modelling Labs `cml` format the subfolder would be `cml`.
 
-Most templates are unique for each node `kind`. Value of `kind` is taken from NetBox `device.platform.slug` field. Interface mapping templates do not depend on the output format, since they are determined by the NOS images used by each `kind`. Therefore, there is a single dedicated folder for them. The full list of template search rules:
+Most templates are unique for each node `kind`. Value of `kind` is taken from NetBox `device.platform.slug` field. The full list of template search rules:
 
 * `<format>/topology.j2`: template for the final topology file.
 * `<format>/kinds/<kind>.j2`: templates for individual node entries in the topology file.
 * `<format>/interface_names/<kind>.j2`: templates for generating emulated interface names used by this NOS `kind`.
-* `interface_maps/<kind>.j2`: templates for mappings between real interface names and emulated interface names used by this NOS `kind`. Not all `kinds` support such mappings.
+* `<format>/interface_maps/<kind>.j2`: templates for mappings between real interface names and emulated interface names used by this NOS `kind`. Not all `kinds` support such mappings.
 
 This repository includes a set of [netreplica/templates](https://github.com/netreplica/templates) as a submodule. See more details about available templates in the [templates/README.md](https://github.com/netreplica/templates).
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ optional arguments:
   -h, --help                show this help message and exit
   -c, --config CONFIG       configuration file
   -i, --input INPUT         input source: netbox (default) | cyjs
-  -o, --output OUTPUT       output format: cyjs for JSON, or any other format supported by provided templates
+  -o, --output OUTPUT       output format: cyjs | clab | cml | graphite | d2 or any other format supported by provided templates
   -a, --api API             netbox API URL
   -s, --site SITE           netbox site to export
   -t, --tags TAGS           netbox tags to export, for multiple tags use a comma-separated list: tag1,tag2,tag3 (uses AND logic)

--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@
 * Topology file for [Cisco Modeling Labs](https://developer.cisco.com/modeling-labs/) platform for network simulation
 * Topology data for visualization using [Graphite](https://github.com/netreplica/graphite) or [D2](https://d2lang.com/)
 * Graph data as a JSON file in [Cytoscape](https://cytoscape.org/) format [CYJS](http://manual.cytoscape.org/en/stable/Supported_Network_File_Formats.html#cytoscape-js-json)
+* Any other user-defined format using [Jinja2](https://palletsprojects.com/p/jinja/) templates
 
 It can also read the topology graph previously saved as a CYJS file to convert it into other formats.
 
 This project is in early phase. We're experimenting with the best ways to automate software network lab orchestration. If you have any feedback, questions or suggestions, please reach out to us via the Netreplica Discord server linked above, [#netreplica](https://netdev-community.slack.com/archives/C054GKBC4LB) channel in NetDev Community on Slack, or open a github issue in this repository.
+
+# Latest capabilities added
+
+The last release adds the following capabilities:
+* User-defined output formats using Jinja2 templates
+
+Find detailed release notes on the [Releases page](https://github.com/netreplica/nrx/releases).
 
 # Table of contents
 
@@ -58,6 +66,7 @@ Export capabilities:
 * Exports the graph as a Cisco Modeling Labs (CML) topology definition file in YAML format
 * Exported device configurations will be used as `startup-config` for Containerlab and CML
 * Exports the graph in formats for visualization with Graphite or D2
+* User-defined output formats using Jinja2 templates
 * Uses NetBox Device Platform `slug` field to identify node templates when rendering the export file
 * Creates mapping between real interface names and interface names used by the supported lab tools
 * Calculates `level` and `rank` values for each node based on Device Role to help visualize the topology
@@ -65,10 +74,10 @@ Export capabilities:
 
 # Compatibility
 
-The following minimum software versions were tested for compatibility with `nrx`:
+The following software versions were tested for compatibility with `nrx`:
 
-* NetBox `v3.4`. For device configuration export, `v3.5` is the minimum version.
-* Containerlab `v0.39`
+* NetBox `v3.4`-`v3.5`. For device configuration export, `v3.5` is the minimum version.
+* Containerlab `v0.39`, but earlier and later versions should work fine
 * Cisco Modeling Labs `v2.5`
 * Netreplica Graphite `v0.4.0`
 
@@ -167,14 +176,14 @@ Use `--config <filename>` argument to specify a configuration file to use. The s
 
 # Templates
 
-**nrx** renders all topology artifacts from [Jinja2](https://jinja.palletsprojects.com/en/3.1.x/) templates. Depending on the desired output format, the required templates are taken from a matching subfolder. For example, if the output format is `clab` for Containerlab, then templates are searched under `clab` subfolder. For Cisco Modelling Labs `cml` format the subfolder would be `cml`.
+**nrx** renders all topology artifacts from [Jinja2](https://jinja.palletsprojects.com/en/3.1.x/) templates. Depending on the desired output format, the required templates are taken from a matching subfolder. For example, if the output format is `clab` for Containerlab, then templates are searched under `clab` subfolder. For Cisco Modelling Labs `cml` format the subfolder would be `cml`. A user can create their own templates for any output format and store them in a subfolder with a format name they would use for `--output` argument.
 
 Most templates are unique for each node `kind`. Value of `kind` is taken from NetBox `device.platform.slug` field. The full list of template search rules:
 
-* `<format>/topology.j2`: template for the final topology file.
-* `<format>/kinds/<kind>.j2`: templates for individual node entries in the topology file.
-* `<format>/interface_names/<kind>.j2`: templates for generating emulated interface names used by this NOS `kind`.
-* `<format>/interface_maps/<kind>.j2`: templates for mappings between real interface names and emulated interface names used by this NOS `kind`. Not all `kinds` support such mappings.
+* `<format>/topology.j2`: template for the final topology file. Mandatory.
+* `<format>/kinds/<kind>.j2`: templates for individual node entries in the topology file, with `default.j2` being mandatory as a fallback template.
+* `<format>/interface_names/<kind>.j2`: templates for generating emulated interface names used by this NOS `kind` with `default.j2` being a fallback template. Optional, as not all formats need emulated interface names.
+* `<format>/interface_maps/<kind>.j2`: templates for mappings between real interface names and emulated interface names used by this NOS `kind`. Optional, as not all `kinds` support such mappings.
 
 This repository includes a set of [netreplica/templates](https://github.com/netreplica/templates) as a submodule. See more details about available templates in the [templates/README.md](https://github.com/netreplica/templates).
 

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -560,7 +560,7 @@ class NetworkTopology:
         self.files_path = create_output_directory(self.topology['name'], self.config['output_dir'])
         # Generate topology data structure
         self.topology['name'] = self.G.name
-        self.topology['nodes'] = self._render_emulated_nodes()
+        self.topology['rendered_nodes'] = self._render_emulated_nodes()
         self._initialize_emulated_links()
         self._render_topology()
 

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -443,15 +443,17 @@ class NetworkTopology:
         template = self._get_template_with_file(file)
         try:
             formats_map = yaml.load(template.render(self.config), Loader=yaml.SafeLoader)
+        except jinja2.TemplateError as e:
+            error(f"[FORMAT] Rendering {file} template as format map: {e}")
         except yaml.scanner.ScannerError as e:
             error("[FORMAT] Can't parse formats map:", e)
         if 'type' in formats_map and formats_map['type'] == 'formats_map' and 'version' in formats_map:
             if formats_map['version'] not in ['v1']:
-                error(f"[FORMAT] Unsupported version of {file}")
+                error(f"[FORMAT] Unsupported version of {file} as format map")
             if self.config['output_format'] not in formats_map['formats']:
-                error(f"[FORMAT] Output format '{self.config['output_format']}' is not found in {file}")
+                error(f"[FORMAT] Output format '{self.config['output_format']}' is not found in {file} under {self.config['templates_path']}")
             return formats_map['formats'][self.config['output_format']]
-        error(f"[FORMAT] Unsupported format in {file}")
+        error(f"[FORMAT] Unsupported 'type' in {file} under {self.config['templates_path']}, has to be a 'formats_map' with a 'version'")
         return None
 
 

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -418,7 +418,7 @@ class NetworkTopology:
         self.j2env.filters['ceil'] = math.ceil
         self.templates = {
             'interface_names': {'_path_': f"{self.config['output_format']}/interface_names", '_description_': 'interface name'},
-            'interface_maps':  {'_path_': 'interface_maps',  '_description_': 'interface map'},
+            'interface_maps':  {'_path_': f"{self.config['output_format']}/interface_maps",  '_description_': 'interface map'},
             'kinds':           {'_path_': f"{self.config['output_format']}/kinds", '_description_': 'node kind'}
         }
         self.files_path = '.'

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -750,21 +750,13 @@ def arg_input_check(s):
         return s
     raise argparse.ArgumentTypeError(f"input source has to be one of {allowed_values}")
 
-def arg_output_check(s):
-    """Check if output format is supported"""
-    allowed_values = ['gml', 'cyjs', 'clab', 'cml', 'graphite', 'd2']
-    if s in allowed_values:
-        return s
-    raise argparse.ArgumentTypeError(f"output format has to be one of {allowed_values}")
-
 def parse_args():
     """CLI arguments parser"""
     parser = argparse.ArgumentParser(prog='nrx', description="nrx - network topology exporter by netreplica")
     parser.add_argument('-c', '--config',    required=False, help='configuration file')
     parser.add_argument('-i', '--input',     required=False, help='input source: netbox (default) | cyjs',
                                              default='netbox', type=arg_input_check,)
-    parser.add_argument('-o', '--output',    required=False, help='output format: cyjs | gml | clab | cml | graphite | d2',
-                                             type=arg_output_check, )
+    parser.add_argument('-o', '--output',    required=False, help='output format: cyjs for JSON, or any other format supported by provided templates')
     parser.add_argument('-a', '--api',       required=False, help='netbox API URL')
     parser.add_argument('-s', '--site',      required=False, help='netbox site to export')
     parser.add_argument('-t', '--tags',      required=False, help='netbox tags to export, for multiple tags use a comma-separated list: tag1,tag2,tag3 (uses AND logic)')
@@ -827,8 +819,6 @@ def load_toml_config(filename):
                 for k in config:
                     if k.upper() in nb_config:
                         config[k] = nb_config[k.upper()]
-                if len(config['output_format']) > 0:
-                    arg_output_check(config['output_format'])
         except OSError as e:
             error(f"Unable to open configuration file {filename}: {e}")
         except toml.decoder.TomlDecodeError as e:
@@ -931,7 +921,7 @@ def main():
     else:
         topo.build_from_graph(nb_network.graph())
 
-    if config['output_format'] in ['clab', 'cml', 'graphite', 'd2']:
+    if config['output_format'] != 'cyjs':
         topo.export_topology()
     else:
         if nb_network is None:

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -690,11 +690,11 @@ class NetworkTopology:
 
     def _write_topology(self, topo):
         topo_file = f"{self.topology['name']}"
-        topo_format = self.config['format']
-        if 'file_extension' in topo_format:
-            topo_file += f".{topo_format['file_extension']}"
-        elif 'file_format' in topo_format:
-            topo_file += f".{self.config['output_format']}.{topo_format['file_format']}"
+        format_params = self.config['format']
+        if 'file_extension' in format_params:
+            topo_file += f".{format_params['file_extension']}"
+        elif 'file_format' in format_params:
+            topo_file += f".{self.config['output_format']}.{format_params['file_format']}"
         try:
             topo_path = f"{self.files_path}/{topo_file}"
             with open(topo_path, "w", encoding="utf-8") as f:

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -789,7 +789,7 @@ def parse_args():
     parser.add_argument('-c', '--config',    required=False, help='configuration file')
     parser.add_argument('-i', '--input',     required=False, help='input source: netbox (default) | cyjs',
                                              default='netbox', type=arg_input_check,)
-    parser.add_argument('-o', '--output',    required=False, help='output format: cyjs for JSON, or any other format supported by provided templates')
+    parser.add_argument('-o', '--output',    required=False, help='output format: cyjs | clab | cml | graphite | d2 or any other format supported by provided templates')
     parser.add_argument('-a', '--api',       required=False, help='netbox API URL')
     parser.add_argument('-s', '--site',      required=False, help='netbox site to export')
     parser.add_argument('-t', '--tags',      required=False, help='netbox tags to export, for multiple tags use a comma-separated list: tag1,tag2,tag3 (uses AND logic)')


### PR DESCRIPTION
`nrx` is no longer restricted to a certain set of output formats and can support new formats provided by a user. As long as there are:

* properly constructed templates that `nrx` can use for the format residing in a subfolder of the same name in the `templates` directory, and
* the format is described in `templates/formats.yaml` map

nrx will use those templates.