### PR TITLE
Implemented versioning, initialization of the configuration environment with default config & templates

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,3 +3,6 @@ disable=C0103,C0301,R0903,C0116,W0603,W0718
 [DESIGN]
 # needed to match number of arguments in requests.send
 max-args=7
+[FORMAT]
+# temporary mix until we break the code into smaller files
+max-module-lines=1200

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ nrx - network topology exporter by netreplica
 
 optional arguments:
   -h, --help                show this help message and exit
+  -d, --debug               enable debug output
+  -I, --init                initialize nrx environment and exit
   -c, --config CONFIG       configuration file
   -i, --input INPUT         input source: netbox (default) | cyjs
   -o, --output OUTPUT       output format: cyjs | clab | cml | graphite | d2 or any other format supported by provided templates
@@ -151,7 +153,6 @@ optional arguments:
   -t, --tags TAGS           netbox tags to export, for multiple tags use a comma-separated list: tag1,tag2,tag3 (uses AND logic)
   -n, --noconfigs           disable device configuration export (enabled by default)
   -k, --insecure            allow insecure server connections when using TLS
-  -d, --debug               enable debug output
   -f, --file FILE           file with the network graph to import
   -T, --templates TEMPLATES directory with template files, will be prepended to TEMPLATES_PATH list in the configuration file
   -D, --dir DIR             save files into directory DIR (topology name is used by default). nested relative and absolute paths are OK

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Find detailed release notes on the [Releases page](https://github.com/netreplica
    * [Command-line arguments](#command-line-arguments)
    * [Environmental variables](#environmental-variables)
    * [Configuration file](#configuration-file)
-   * [Configuration environment](#configuration-environment)
+   * [Configuration directory](#configuration-directory)
 * [Templates](#templates)
 * [How to use](#how-to-use)
    * [Containerlab example](#containerlab-example)
@@ -146,7 +146,7 @@ optional arguments:
   -h, --help                show this help message and exit
   -v, --version             show version number and exit
   -d, --debug               enable debug output
-  -I, --init                initialize nrx environment in $HOME/.nr and exit
+  -I, --init                initialize configuration directory in $HOME/.nr and exit
   -c, --config CONFIG       configuration file, default: $HOME/.nr/nrx.conf
   -i, --input INPUT         input source: netbox (default) | cyjs
   -o, --output OUTPUT       output format: cyjs | clab | cml | graphite | d2 or any other format supported by provided templates
@@ -177,14 +177,14 @@ export NB_API_TOKEN='replace_with_valid_API_token'
 
 Use `--config <filename>` argument to specify a configuration file to use. By default, **nrx** uses `$HOME/.nr/nrx.conf` if such file exists. The sample configuration file is provided as [`nrx.conf`](nrx.conf). Detailed information on the configuration options can be found in [CONFIGURATION.md](docs/CONFIGURATION.md).
 
-## Configuration environment
+## Configuration directory
 
 By default, **nrx** looks up for the following assets in the `$HOME/.nr` directory:
 
 * Configuration file: `nrx.conf`, unless overridden by `--config` argument
 * Templates: `templates`, which can be supplemented by additional paths with `--templates` argument
 
-To initialize the configuration environment, run `nrx.py --init`. This will create the `$HOME/.nr` directory and populate it with a configuration file example and a compatible version of the templates.
+To initialize the configuration directory, run `nrx.py --init`. This will create the `$HOME/.nr` folder and populate it with a configuration file example and a compatible version of the templates.
 
 # Templates
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ optional arguments:
   -v, --version             show version number and exit
   -d, --debug               enable debug output
   -I, --init                initialize nrx environment and exit
-  -c, --config CONFIG       configuration file
+  -c, --config CONFIG       configuration file, default: $HOME/.nr/nrx.conf
   -i, --input INPUT         input source: netbox (default) | cyjs
   -o, --output OUTPUT       output format: cyjs | clab | cml | graphite | d2 or any other format supported by provided templates
   -a, --api API             netbox API URL
@@ -174,7 +174,7 @@ export NB_API_TOKEN='replace_with_valid_API_token'
 
 ## Configuration file
 
-Use `--config <filename>` argument to specify a configuration file to use. The sample configuration file is provided as [`nrx.conf`](nrx.conf). Detailed information on the configuration options can be found in [CONFIGURATION.md](docs/CONFIGURATION.md).
+Use `--config <filename>` argument to specify a configuration file to use. By default, **nrx** uses `$HOME/.nr/nrx.conf` if such file exists. The sample configuration file is provided as [`nrx.conf`](nrx.conf). Detailed information on the configuration options can be found in [CONFIGURATION.md](docs/CONFIGURATION.md).
 
 # Configuration Environment
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ export NB_API_TOKEN='replace_with_valid_API_token'
 
 Use `--config <filename>` argument to specify a configuration file to use. The sample configuration file is provided as [`nrx.conf`](nrx.conf). Detailed information on the configuration options can be found in [CONFIGURATION.md](docs/CONFIGURATION.md).
 
+# Configuration Environment
+
+By default, **nrx** looks up for the following assets in the `$HOME/.nr` directory:
+
+* Configuration file: `nrx.conf`, unless overridden by `--config` argument
+* Templates: `templates`, which can be supplemented by additional paths with `--templates` argument
+
+To initialize the configuration environment, run `nrx.py --init`. This will create the `$HOME/.nr` directory and populate it with a configuration file example and a compatible version of the templates.
+
 # Templates
 
 **nrx** renders all topology artifacts from [Jinja2](https://jinja.palletsprojects.com/en/3.1.x/) templates the user points `nrx` to using `--templates` parameter.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ optional arguments:
   -h, --help                show this help message and exit
   -v, --version             show version number and exit
   -d, --debug               enable debug output
-  -I, --init                initialize nrx environment and exit
+  -I, --init                initialize nrx environment in $HOME/.nr and exit
   -c, --config CONFIG       configuration file, default: $HOME/.nr/nrx.conf
   -i, --input INPUT         input source: netbox (default) | cyjs
   -o, --output OUTPUT       output format: cyjs | clab | cml | graphite | d2 or any other format supported by provided templates

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ nrx - network topology exporter by netreplica
 
 optional arguments:
   -h, --help                show this help message and exit
+  -v, --version             show version number and exit
   -d, --debug               enable debug output
   -I, --init                initialize nrx environment and exit
   -c, --config CONFIG       configuration file

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Find detailed release notes on the [Releases page](https://github.com/netreplica
    * [Command-line arguments](#command-line-arguments)
    * [Environmental variables](#environmental-variables)
    * [Configuration file](#configuration-file)
+   * [Configuration environment](#configuration-environment)
 * [Templates](#templates)
 * [How to use](#how-to-use)
    * [Containerlab example](#containerlab-example)
@@ -176,7 +177,7 @@ export NB_API_TOKEN='replace_with_valid_API_token'
 
 Use `--config <filename>` argument to specify a configuration file to use. By default, **nrx** uses `$HOME/.nr/nrx.conf` if such file exists. The sample configuration file is provided as [`nrx.conf`](nrx.conf). Detailed information on the configuration options can be found in [CONFIGURATION.md](docs/CONFIGURATION.md).
 
-# Configuration Environment
+## Configuration environment
 
 By default, **nrx** looks up for the following assets in the `$HOME/.nr` directory:
 

--- a/nrx.conf
+++ b/nrx.conf
@@ -13,7 +13,7 @@
 # List of NetBox Device Roles to export
 ;EXPORT_DEVICE_ROLES  = ['router', 'core-switch', 'distribution-switch', 'access-switch', 'tor-switch']
 # NetBox Site to export. Alternatively, use --site argument
-;EXPORT_SITE          = 'DM-Akron'
+;EXPORT_SITE          = 'DC1'
 # NetBox tags to export. Alternatively, use --tags argument
 ;EXPORT_TAGS          = []
 # Export device configurations, when available

--- a/nrx.conf
+++ b/nrx.conf
@@ -1,34 +1,34 @@
 # NetBox API URL. Alternatively, use --api argument or NB_API_URL environmental variable
-NB_API_URL           = 'https://demo.netbox.dev'
+;NB_API_URL           = ''
 # NetBox API Token. Alternatively, use NB_API_TOKEN environmental variable
-NB_API_TOKEN         = ''
+;NB_API_TOKEN         = ''
 # Peform TLS certification validation
-TLS_VALIDATE	     = true
+;TLS_VALIDATE	     = true
 # API request timeout, in seconds
-API_TIMEOUT          = 10
+;API_TIMEOUT          = 10
 # Output format to use for export: 'gml' | 'cyjs' | 'clab'. Alternatively, use --output argument
-OUTPUT_FORMAT        = 'clab'
+;OUTPUT_FORMAT        = 'clab'
 # Override output directory. By default, a subdirectory matching topology name will be created. Alternatively, use --dir argument
-OUTPUT_DIR           = 'demo'
+;OUTPUT_DIR           = 'demo'
 # List of NetBox Device Roles to export
-EXPORT_DEVICE_ROLES  = ['router', 'core-switch', 'distribution-switch', 'access-switch', 'tor-switch', 'server']
+;EXPORT_DEVICE_ROLES  = ['router', 'core-switch', 'distribution-switch', 'access-switch', 'tor-switch']
 # NetBox Site to export. Alternatively, use --site argument
-EXPORT_SITE          = 'DM-Akron'
+;EXPORT_SITE          = 'DM-Akron'
 # NetBox tags to export. Alternatively, use --tags argument
-EXPORT_TAGS          = []
+;EXPORT_TAGS          = []
 # Export device configurations, when available
-EXPORT_CONFIGS       = true
+;EXPORT_CONFIGS       = true
 # Templates path
-TEMPLATES_PATH       = ['templates']
+;TEMPLATES_PATH       = ['templates']
 # Levels of device roles for visualization
 [DEVICE_ROLE_LEVELS]
-unknown =              0
-server =               0
-tor-switch =           1
-access-switch =        1
-leaf =                 1
-distribution-switch =  2
-spine =                2
-core-switch =          3
-super-spine =          3
-router =               4
+;unknown =              0
+;server =               0
+;tor-switch =           1
+;access-switch =        1
+;leaf =                 1
+;distribution-switch =  2
+;spine =                2
+;core-switch =          3
+;super-spine =          3
+;router =               4

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -51,6 +51,7 @@ import yaml
 
 DEBUG_ON = False
 NRX_ENV_DIR = ".nr"
+NRX_DEFAULT_CONFIG_NAME = "nrx.conf"
 NRX_REPOSITORY = "https://github.com/netreplica/nrx"
 NRX_TEMPLATES_REPOSITORY = "https://github.com/netreplica/templates"
 NRX_REPOSITORY_TIMEOUT = 10
@@ -59,6 +60,10 @@ NRX_REPOSITORY_TIMEOUT = 10
 def nrx_env_path():
     """Return path to the nrx environment directory"""
     return f"{os.getenv('HOME', os.getcwd())}/{NRX_ENV_DIR}"
+
+def nrx_default_config_path():
+    """Return path to the default nrx configuration file"""
+    return f"{nrx_env_path()}/{NRX_DEFAULT_CONFIG_NAME}"
 
 def errlog(*args, **kwargs):
     """print message on STDERR"""
@@ -684,7 +689,7 @@ class NetworkTopology:
         template = None
         try:
             template = self.j2env.get_template(j2file)
-            debug(f"Found template {j2file}")
+            debug(f"Found template {template.filename}")
         except (OSError, jinja2.TemplateError) as e:
             m = f"Unable to open template '{j2file}' with path {self.config['templates_path']}."
             m += f" Make sure you have a compatible version of the templates repository."
@@ -844,7 +849,8 @@ def parse_args():
     parser.add_argument('-v', '--version',   action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('-d', '--debug',     nargs=0, action=NrxDebugAction, help='enable debug output')
     parser.add_argument('-I', '--init',      nargs=0, action=NrxInitAction, help='initialize nrx environment and exit')
-    parser.add_argument('-c', '--config',    required=False, help='configuration file')
+    parser.add_argument('-c', '--config',    required=False, help=f"configuration file, default: $HOME/{NRX_ENV_DIR}/{NRX_DEFAULT_CONFIG_NAME}",
+                                             default=nrx_default_config_path())
     parser.add_argument('-i', '--input',     required=False, help='input source: netbox (default) | cyjs',
                                              default='netbox', type=arg_input_check,)
     parser.add_argument('-o', '--output',    required=False, help='output format: cyjs | clab | cml | graphite | d2 or any other format supported by provided templates')
@@ -995,7 +1001,7 @@ def load_toml_config(filename):
         'export_site': '',
         'export_tags': [],
         'export_configs': True,
-        'templates_path': ["templates", f"{nrx_env_path()}/templates"],
+        'templates_path': ["./templates", f"{nrx_env_path()}/templates"],
         'formats_map': 'formats.yaml',
         'output_dir': '',
         'nb_api_params': {
@@ -1011,7 +1017,10 @@ def load_toml_config(filename):
                     if k.upper() in nb_config:
                         config[k] = nb_config[k.upper()]
         except OSError as e:
-            error(f"Unable to open configuration file {filename}: {e}")
+            if filename == nrx_default_config_path():
+                debug(f"Can't open default configuration file, ignoring.", e)
+            else:
+                error(f"Unable to open configuration file:", e)
         except toml.decoder.TomlDecodeError as e:
             error(f"Unable to parse configuration file {filename}: {e}")
         except argparse.ArgumentTypeError as e:

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -57,13 +57,13 @@ NRX_TEMPLATES_REPOSITORY = "https://github.com/netreplica/templates"
 NRX_REPOSITORY_TIMEOUT = 10
 
 
-def nrx_env_path():
-    """Return path to the nrx environment directory"""
+def nrx_config_dir():
+    """Return path to the nrx configuration directory"""
     return f"{os.getenv('HOME', os.getcwd())}/{NRX_ENV_DIR}"
 
 def nrx_default_config_path():
     """Return path to the default nrx configuration file"""
-    return f"{nrx_env_path()}/{NRX_DEFAULT_CONFIG_NAME}"
+    return f"{nrx_config_dir()}/{NRX_DEFAULT_CONFIG_NAME}"
 
 def errlog(*args, **kwargs):
     """print message on STDERR"""
@@ -852,7 +852,7 @@ def parse_args():
     parser = argparse.ArgumentParser(prog='nrx', description="nrx - network topology exporter by netreplica")
     parser.add_argument('-v', '--version',   action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('-d', '--debug',     nargs=0, action=NrxDebugAction, help='enable debug output')
-    parser.add_argument('-I', '--init',      nargs=0, action=NrxInitAction, help=f"initialize nrx environment in $HOME/{NRX_ENV_DIR} and exit")
+    parser.add_argument('-I', '--init',      nargs=0, action=NrxInitAction, help=f"initialize configuration directory in $HOME/{NRX_ENV_DIR} and exit")
     parser.add_argument('-c', '--config',    required=False, help=f"configuration file, default: $HOME/{NRX_ENV_DIR}/{NRX_DEFAULT_CONFIG_NAME}",
                                              default=nrx_default_config_path())
     parser.add_argument('-i', '--input',     required=False, help='input source: netbox (default) | cyjs',
@@ -887,11 +887,11 @@ class NrxDebugAction(argparse.Action):
 
 
 class NrxInitAction(argparse.Action):
-    """Argparse action to initialize nrx environment"""
+    """Argparse action to initialize configuration directory"""
     def __call__(self, parser, namespace, values, option_string=None):
         # Create a NRX_ENV_DIR directory in the user's home directory, or in the current directory if HOME is not set
-        env_path = nrx_env_path()
-        print(f"[INIT] Initializing nrx environment in {env_path}")
+        env_path = nrx_config_dir()
+        print(f"[INIT] Initializing configuration directory in {env_path}")
         env_dir = create_dirs(env_path)
         # Get asset matrix versions.yaml
         versions = get_versions(__version__)
@@ -1005,7 +1005,7 @@ def load_toml_config(filename):
         'export_site': '',
         'export_tags': [],
         'export_configs': True,
-        'templates_path': ["./templates", f"{nrx_env_path()}/templates"],
+        'templates_path': ["./templates", f"{nrx_config_dir()}/templates"],
         'formats_map': 'formats.yaml',
         'output_dir': '',
         'nb_api_params': {

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -868,6 +868,12 @@ def get_templates(versions, dir_path):
                         debug(f"[TEMPLATES] Unzipped templates to {dir_path}")
                 except (zipfile.BadZipFile, FileNotFoundError, Exception) as e:
                     error(f"[TEMPLATES] Can't unzip {zip_path}: {e}")
+                # Remove zip file
+                try:
+                    os.remove(zip_path)
+                    debug(f"[TEMPLATES] Deleted {zip_path}")
+                except OSError as e:
+                    error(f"[TEMPLATES] Can't delete {zip_path}: {e}")
                 return templates_path
         else:
             error(f"[TEMPLATES] Can't download templates from {templates_url}, status code: {r.status_code}")

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -52,6 +52,7 @@ import yaml
 DEBUG_ON = False
 NRX_CONFIG_DIR = ".nr"
 NRX_DEFAULT_CONFIG_NAME = "nrx.conf"
+NRX_VERSIONS_NAME = "versions.yaml"
 NRX_REPOSITORY = "https://github.com/netreplica/nrx"
 NRX_TEMPLATES_REPOSITORY = "https://github.com/netreplica/templates"
 NRX_REPOSITORY_TIMEOUT = 10
@@ -893,7 +894,7 @@ class NrxInitAction(argparse.Action):
         config_dir_path = nrx_config_dir()
         print(f"[INIT] Initializing configuration directory in {config_dir_path}")
         config_dir = create_dirs(config_dir_path)
-        # Get asset matrix versions.yaml
+        # Get asset NRX_VERSIONS_NAME with versions compatibility matrix
         versions = get_versions(__version__)
         templates_path = get_templates(versions, config_dir)
         if templates_path is not None:
@@ -909,8 +910,8 @@ class NrxInitAction(argparse.Action):
 
 
 def get_versions(nrx_version):
-    """Download and parse versions.yaml asset file for a specific nrx version"""
-    versions_url = f"{NRX_REPOSITORY}/releases/download/{nrx_version}/versions.yaml"
+    """Download and parse NRX_VERSIONS_NAME asset file for a specific nrx version"""
+    versions_url = f"{NRX_REPOSITORY}/releases/download/{nrx_version}/{NRX_VERSIONS_NAME}"
     try:
         r = requests.get(versions_url, timeout=NRX_REPOSITORY_TIMEOUT)
     except (HTTPError, Timeout, RequestException) as e:

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -687,7 +687,7 @@ class NetworkTopology:
             debug(f"Found template {j2file}")
         except (OSError, jinja2.TemplateError) as e:
             m = f"Unable to open template '{j2file}' with path {self.config['templates_path']}."
-            m += f" Reason: {e}"
+            m += f" Make sure you have a compatible version of the templates repository."
             error(m)
         return template
 

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -690,9 +690,13 @@ class NetworkTopology:
         try:
             template = self.j2env.get_template(j2file)
             debug(f"Found template {template.filename}")
-        except (OSError, jinja2.TemplateError) as e:
+        except OSError:
             m = f"Unable to open template '{j2file}' with path {self.config['templates_path']}."
-            m += f" Make sure you have a compatible version of the templates repository."
+            m += " Make sure you have a compatible version of the templates repository."
+            error(m)
+        except jinja2.TemplateError as e:
+            m = f"Unable to open use '{j2file}' with path {self.config['templates_path']}."
+            m += f" Reason: {e}."
             error(m)
         return template
 
@@ -1018,9 +1022,9 @@ def load_toml_config(filename):
                         config[k] = nb_config[k.upper()]
         except OSError as e:
             if filename == nrx_default_config_path():
-                debug(f"Can't open default configuration file, ignoring.", e)
+                debug("Can't open default configuration file, ignoring.", e)
             else:
-                error(f"Unable to open configuration file:", e)
+                error("Unable to open configuration file:", e)
         except toml.decoder.TomlDecodeError as e:
             error(f"Unable to parse configuration file {filename}: {e}")
         except argparse.ArgumentTypeError as e:

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -30,11 +30,6 @@ It can also read the topology graph previously saved as a CYJS file to convert i
 __version__ = 'v0.3.0'
 __author__ = 'Alex Bortok and Netreplica Team'
 
-NRX_ENV_DIR = ".nr"
-NRX_REPOSITORY = "https://github.com/netreplica/nrx"
-NRX_TEMPLATES_REPOSITORY = "https://github.com/netreplica/templates"
-NRX_REPOSITORY_TIMEOUT = 10
-
 import os
 import sys
 import argparse
@@ -55,6 +50,11 @@ import yaml
 # DEFINE GLOBAL VARs HERE
 
 DEBUG_ON = False
+NRX_ENV_DIR = ".nr"
+NRX_REPOSITORY = "https://github.com/netreplica/nrx"
+NRX_TEMPLATES_REPOSITORY = "https://github.com/netreplica/templates"
+NRX_REPOSITORY_TIMEOUT = 10
+
 
 def errlog(*args, **kwargs):
     """print message on STDERR"""
@@ -886,6 +886,23 @@ def get_templates(versions, dir_path):
                             debug(f"[TEMPLATES] Unzipped templates to {dir_path}")
                     except (zipfile.BadZipFile, FileNotFoundError, Exception) as e:
                         error(f"[TEMPLATES] Can't unzip {zip_path}: {e}")
+                    # Remove an existing symlink to templates
+                    if os.path.exists(f"{dir_path}/templates"):
+                        if os.path.islink(f"{dir_path}/templates"):
+                            try:
+                                os.remove(f"{dir_path}/templates")
+                                debug(f"[TEMPLATES] Deleted existing symlink {dir_path}/templates")
+                            except OSError as e:
+                                warning(f"[TEMPLATES] Can't delete existing symlink {dir_path}/templates: {e}, skipping. Use '--templates {templates_path}' argument instead")
+                        else:
+                            warning(f"[TEMPLATES] {dir_path}/templates exists and is not a symlink, skipping. Use '--templates {templates_path}' argument instead")
+                    # Create a symlink
+                    if not os.path.exists(f"{dir_path}/templates"):
+                        try:
+                            os.symlink(templates_path, f"{dir_path}/templates")
+                            debug(f"[TEMPLATES] Created a symlink to templates: {dir_path}/templates")
+                        except OSError as e:
+                            error(f"[TEMPLATES] Can't create a symlink to templates: {e}")
                     # Remove zip file
                     try:
                         os.remove(zip_path)

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -27,7 +27,7 @@ nrx reads a network topology graph from NetBox DCIM system and exports it in one
 It can also read the topology graph previously saved as a CYJS file to convert it into the one of supported network emulation formats.
 """
 
-__version__ = 'v0.3.0'
+__version__ = 'v0.4.0'
 __author__ = 'Alex Bortok and Netreplica Team'
 
 import os

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -890,17 +890,17 @@ class NrxInitAction(argparse.Action):
     """Argparse action to initialize configuration directory"""
     def __call__(self, parser, namespace, values, option_string=None):
         # Create a NRX_CONFIG_DIR directory in the user's home directory, or in the current directory if HOME is not set
-        env_path = nrx_config_dir()
-        print(f"[INIT] Initializing configuration directory in {env_path}")
-        env_dir = create_dirs(env_path)
+        config_dir_path = nrx_config_dir()
+        print(f"[INIT] Initializing configuration directory in {config_dir_path}")
+        config_dir = create_dirs(config_dir_path)
         # Get asset matrix versions.yaml
         versions = get_versions(__version__)
-        templates_path = get_templates(versions, env_dir)
+        templates_path = get_templates(versions, config_dir)
         if templates_path is not None:
             print(f"[INIT] Saved templates to: {templates_path}")
         else:
             error("[INIT] Can't download templates")
-        default_config_path = get_default_config(versions, env_dir)
+        default_config_path = get_default_config(versions, config_dir)
         if default_config_path is not None:
             print(f"[INIT] Saved default config to: {default_config_path}. Rename it as nrx.conf and edit as needed")
         else:

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -852,7 +852,7 @@ def parse_args():
     parser = argparse.ArgumentParser(prog='nrx', description="nrx - network topology exporter by netreplica")
     parser.add_argument('-v', '--version',   action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('-d', '--debug',     nargs=0, action=NrxDebugAction, help='enable debug output')
-    parser.add_argument('-I', '--init',      nargs=0, action=NrxInitAction, help='initialize nrx environment and exit')
+    parser.add_argument('-I', '--init',      nargs=0, action=NrxInitAction, help=f"initialize nrx environment in $HOME/{NRX_ENV_DIR} and exit")
     parser.add_argument('-c', '--config',    required=False, help=f"configuration file, default: $HOME/{NRX_ENV_DIR}/{NRX_DEFAULT_CONFIG_NAME}",
                                              default=nrx_default_config_path())
     parser.add_argument('-i', '--input',     required=False, help='input source: netbox (default) | cyjs',

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -27,6 +27,9 @@ nrx reads a network topology graph from NetBox DCIM system and exports it in one
 It can also read the topology graph previously saved as a CYJS file to convert it into the one of supported network emulation formats.
 """
 
+__version__ = 'v0.3.0'
+__author__ = 'Alex Bortok and Netreplica Team'
+
 import os
 import sys
 import argparse
@@ -787,8 +790,8 @@ def arg_input_check(s):
 def parse_args():
     """CLI arguments parser"""
     parser = argparse.ArgumentParser(prog='nrx', description="nrx - network topology exporter by netreplica")
+    parser.add_argument('-v', '--version',   action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('-d', '--debug',     nargs=0, action=NrxDebugAction, help='enable debug output')
-    #parser.add_argument('-V', '--version',   action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('-I', '--init',      nargs=0, action=NrxInitAction, help='initialize nrx environment and exit')
     parser.add_argument('-c', '--config',    required=False, help='configuration file')
     parser.add_argument('-i', '--input',     required=False, help='input source: netbox (default) | cyjs',
@@ -830,7 +833,7 @@ class NrxInitAction(argparse.Action):
         print(f"[INIT] Initializing nrx environment in {env_path}")
         env_dir = create_dirs(env_path)
         # Get asset matrix versions.yaml
-        versions = get_versions('v0.3.0')
+        versions = get_versions(__version__)
         templates_path = get_templates(versions, env_dir)
         if templates_path is not None:
             print(f"[INIT] Saved templates to: {templates_path}")

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -30,6 +30,11 @@ It can also read the topology graph previously saved as a CYJS file to convert i
 __version__ = 'v0.3.0'
 __author__ = 'Alex Bortok and Netreplica Team'
 
+NRX_ENV_DIR = ".nr"
+NRX_REPOSITORY = "https://github.com/netreplica/nrx"
+NRX_TEMPLATES_REPOSITORY = "https://github.com/netreplica/templates"
+NRX_REPOSITORY_TIMEOUT = 10
+
 import os
 import sys
 import argparse
@@ -828,8 +833,8 @@ class NrxDebugAction(argparse.Action):
 class NrxInitAction(argparse.Action):
     """Argparse action to initialize nrx environment"""
     def __call__(self, parser, namespace, values, option_string=None):
-        # Create a .nr directory in the user's home directory, or in the current directory if HOME is not set
-        env_path = f"{os.getenv('HOME', os.getcwd())}/.nr"
+        # Create a NRX_ENV_DIR directory in the user's home directory, or in the current directory if HOME is not set
+        env_path = f"{os.getenv('HOME', os.getcwd())}/{NRX_ENV_DIR}"
         print(f"[INIT] Initializing nrx environment in {env_path}")
         env_dir = create_dirs(env_path)
         # Get asset matrix versions.yaml
@@ -844,10 +849,9 @@ class NrxInitAction(argparse.Action):
 
 def get_versions(nrx_version):
     """Download and parse versions.yaml asset file for a specific nrx version"""
-    versions_url = f"https://github.com/netreplica/nrx/releases/download/{nrx_version}/versions.yaml"
-    timeout=10
+    versions_url = f"{NRX_REPOSITORY}/releases/download/{nrx_version}/versions.yaml"
     try:
-        r = requests.get(versions_url, timeout=timeout)
+        r = requests.get(versions_url, timeout=NRX_REPOSITORY_TIMEOUT)
     except (HTTPError, Timeout, RequestException) as e:
         error(f"[VERSIONS] Downloading versions map from {versions_url} failed: {e}")
     if r.status_code == 200:
@@ -862,10 +866,9 @@ def get_templates(versions, dir_path):
     """Download netreplica/templates version from the versions dict provided as a parameter"""
     if versions is not None and 'templates' in versions:
         templates_version = versions['templates']
-        templates_url = f"https://github.com/netreplica/templates/archive/refs/tags/{templates_version}.zip"
-        timeout=10
+        templates_url = f"{NRX_TEMPLATES_REPOSITORY}/archive/refs/tags/{templates_version}.zip"
         try:
-            r = requests.get(templates_url, timeout=timeout)
+            r = requests.get(templates_url, timeout=NRX_REPOSITORY_TIMEOUT)
         except (HTTPError, Timeout, RequestException) as e:
             error(f"[TEMPLATES] Downloading templates from {templates_url} failed: {e}")
         if r.status_code == 200:

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -902,7 +902,7 @@ class NrxInitAction(argparse.Action):
             error("[INIT] Can't download templates")
         default_config_path = get_default_config(versions, config_dir)
         if default_config_path is not None:
-            print(f"[INIT] Saved default config to: {default_config_path}. Rename it as nrx.conf and edit as needed")
+            print(f"[INIT] Saved default config to: {default_config_path}. Rename it as {NRX_DEFAULT_CONFIG_NAME} and edit as needed")
         else:
             error("[INIT] Can't download default config")
         sys.exit(0)
@@ -957,16 +957,16 @@ def get_templates(versions, dir_path):
 
 
 def get_default_config(versions, dir_path):
-    """Download nrx.conf from the assets of the provided release"""
+    """Download NRX_DEFAULT_CONFIG_NAME from the assets of the provided release"""
     if versions is not None and 'nrx' in versions:
         asset_version = versions['nrx']
-        asset_url = f"{NRX_REPOSITORY}/releases/download/{asset_version}/nrx.conf"
+        asset_url = f"{NRX_REPOSITORY}/releases/download/{asset_version}/{NRX_DEFAULT_CONFIG_NAME}"
         try:
             r = requests.get(asset_url, timeout=NRX_REPOSITORY_TIMEOUT)
         except (HTTPError, Timeout, RequestException) as e:
             error(f"[DEFAULT_CONFIG] Downloading default config from {asset_url} failed: {e}")
         if r.status_code == 200:
-            asset_file = f"nrx.conf-{asset_version.lstrip('v')}"
+            asset_file = f"{NRX_DEFAULT_CONFIG_NAME}-{asset_version.lstrip('v')}"
             asset_path = f"{dir_path}/{asset_file}"
             try:
                 with open(asset_path, 'wb') as f:

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -42,6 +42,7 @@ import urllib3
 import networkx as nx
 import jinja2
 import yaml
+import zipfile
 
 # DEFINE GLOBAL VARs HERE
 
@@ -854,11 +855,19 @@ def get_templates(versions, dir_path):
         templates_url = f"https://github.com/netreplica/templates/archive/refs/tags/{templates_version}.zip"
         r = requests.get(templates_url)
         if r.status_code == 200:
-            templates_path = f"{dir_path}/templates_{templates_version}.zip"
-            with open(templates_path, 'wb') as f:
+            zip_file = f"templates_{templates_version}.zip"
+            zip_path = f"{dir_path}/{zip_file}"
+            templates_path = f"{dir_path}/templates-{templates_version.lstrip('v')}"
+            with open(zip_path, 'wb') as f:
                 f.write(r.content)
                 debug(f"[TEMPLATES] Downloaded templates from {templates_url}")
+                # Unzip
+                with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+                    zip_ref.extractall(dir_path)
+                    debug(f"[TEMPLATES] Unzipped templates to {dir_path}")
                 return templates_path
+        else:
+            error(f"[TEMPLATES] Can't download templates from {templates_url}, status code: {r.status_code}")
     return None
 
 

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -56,6 +56,10 @@ NRX_TEMPLATES_REPOSITORY = "https://github.com/netreplica/templates"
 NRX_REPOSITORY_TIMEOUT = 10
 
 
+def nrx_env_path():
+    """Return path to the nrx environment directory"""
+    return f"{os.getenv('HOME', os.getcwd())}/{NRX_ENV_DIR}"
+
 def errlog(*args, **kwargs):
     """print message on STDERR"""
     print(*args, file=sys.stderr, **kwargs)
@@ -876,7 +880,7 @@ class NrxInitAction(argparse.Action):
     """Argparse action to initialize nrx environment"""
     def __call__(self, parser, namespace, values, option_string=None):
         # Create a NRX_ENV_DIR directory in the user's home directory, or in the current directory if HOME is not set
-        env_path = f"{os.getenv('HOME', os.getcwd())}/{NRX_ENV_DIR}"
+        env_path = nrx_env_path()
         print(f"[INIT] Initializing nrx environment in {env_path}")
         env_dir = create_dirs(env_path)
         # Get asset matrix versions.yaml
@@ -991,7 +995,7 @@ def load_toml_config(filename):
         'export_site': '',
         'export_tags': [],
         'export_configs': True,
-        'templates_path': ['.'],
+        'templates_path': ["templates", f"{nrx_env_path()}/templates"],
         'formats_map': 'formats.yaml',
         'output_dir': '',
         'nb_api_params': {

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -33,6 +33,7 @@ import argparse
 import json
 import math
 import ast
+import zipfile
 import toml
 import pynetbox
 import requests
@@ -42,7 +43,6 @@ import urllib3
 import networkx as nx
 import jinja2
 import yaml
-import zipfile
 
 # DEFINE GLOBAL VARs HERE
 
@@ -862,9 +862,12 @@ def get_templates(versions, dir_path):
                 f.write(r.content)
                 debug(f"[TEMPLATES] Downloaded templates from {templates_url}")
                 # Unzip
-                with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-                    zip_ref.extractall(dir_path)
-                    debug(f"[TEMPLATES] Unzipped templates to {dir_path}")
+                try:
+                    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+                        zip_ref.extractall(dir_path)
+                        debug(f"[TEMPLATES] Unzipped templates to {dir_path}")
+                except (zipfile.BadZipFile, FileNotFoundError, Exception) as e:
+                    error(f"[TEMPLATES] Can't unzip {zip_path}: {e}")
                 return templates_path
         else:
             error(f"[TEMPLATES] Can't download templates from {templates_url}, status code: {r.status_code}")

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -50,7 +50,7 @@ import yaml
 # DEFINE GLOBAL VARs HERE
 
 DEBUG_ON = False
-NRX_ENV_DIR = ".nr"
+NRX_CONFIG_DIR = ".nr"
 NRX_DEFAULT_CONFIG_NAME = "nrx.conf"
 NRX_REPOSITORY = "https://github.com/netreplica/nrx"
 NRX_TEMPLATES_REPOSITORY = "https://github.com/netreplica/templates"
@@ -59,7 +59,7 @@ NRX_REPOSITORY_TIMEOUT = 10
 
 def nrx_config_dir():
     """Return path to the nrx configuration directory"""
-    return f"{os.getenv('HOME', os.getcwd())}/{NRX_ENV_DIR}"
+    return f"{os.getenv('HOME', os.getcwd())}/{NRX_CONFIG_DIR}"
 
 def nrx_default_config_path():
     """Return path to the default nrx configuration file"""
@@ -852,8 +852,8 @@ def parse_args():
     parser = argparse.ArgumentParser(prog='nrx', description="nrx - network topology exporter by netreplica")
     parser.add_argument('-v', '--version',   action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('-d', '--debug',     nargs=0, action=NrxDebugAction, help='enable debug output')
-    parser.add_argument('-I', '--init',      nargs=0, action=NrxInitAction, help=f"initialize configuration directory in $HOME/{NRX_ENV_DIR} and exit")
-    parser.add_argument('-c', '--config',    required=False, help=f"configuration file, default: $HOME/{NRX_ENV_DIR}/{NRX_DEFAULT_CONFIG_NAME}",
+    parser.add_argument('-I', '--init',      nargs=0, action=NrxInitAction, help=f"initialize configuration directory in $HOME/{NRX_CONFIG_DIR} and exit")
+    parser.add_argument('-c', '--config',    required=False, help=f"configuration file, default: $HOME/{NRX_CONFIG_DIR}/{NRX_DEFAULT_CONFIG_NAME}",
                                              default=nrx_default_config_path())
     parser.add_argument('-i', '--input',     required=False, help='input source: netbox (default) | cyjs',
                                              default='netbox', type=arg_input_check,)
@@ -889,7 +889,7 @@ class NrxDebugAction(argparse.Action):
 class NrxInitAction(argparse.Action):
     """Argparse action to initialize configuration directory"""
     def __call__(self, parser, namespace, values, option_string=None):
-        # Create a NRX_ENV_DIR directory in the user's home directory, or in the current directory if HOME is not set
+        # Create a NRX_CONFIG_DIR directory in the user's home directory, or in the current directory if HOME is not set
         env_path = nrx_config_dir()
         print(f"[INIT] Initializing configuration directory in {env_path}")
         env_dir = create_dirs(env_path)

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,0 +1,2 @@
+nrx: v0.3.0
+templates: v0.1.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,2 +1,2 @@
-nrx: v0.3.0
-templates: v0.1.0
+nrx: v0.4.0
+templates: v0.2.0


### PR DESCRIPTION
```
  -v, --version             show version number and exit
  -I, --init                initialize nrx environment and exit
```

Default configuration file: `$HOME/.nr/nrx.conf`
Default templates: `['./templates', '$HOME/.nr/templates']`

Uses `versions.yaml` from the release assets published on github to determine which release of the `templates` to download.