### PR TITLE
Added support for ENV vars in filesystem path parameters in `nrx.conf`

### DIFF
--- a/nrx.conf
+++ b/nrx.conf
@@ -1,5 +1,5 @@
 # NetBox API URL. Alternatively, use --api argument or NB_API_URL environmental variable
-;NB_API_URL           = ''
+;NB_API_URL           = 'https://demo.netbox.dev'
 # NetBox API Token. Alternatively, use NB_API_TOKEN environmental variable
 ;NB_API_TOKEN         = ''
 # Peform TLS certification validation
@@ -8,8 +8,8 @@
 ;API_TIMEOUT          = 10
 # Output format to use for export: 'gml' | 'cyjs' | 'clab'. Alternatively, use --output argument
 ;OUTPUT_FORMAT        = 'clab'
-# Override output directory. By default, a subdirectory matching topology name will be created. Alternatively, use --dir argument
-;OUTPUT_DIR           = 'demo'
+# Override output directory. By default, a subdirectory matching topology name will be created. Alternatively, use --dir argument. Env vars are supported
+;OUTPUT_DIR           = '$HOME/nrx'
 # List of NetBox Device Roles to export
 ;EXPORT_DEVICE_ROLES  = ['router', 'core-switch', 'distribution-switch', 'access-switch', 'tor-switch']
 # NetBox Site to export. Alternatively, use --site argument
@@ -18,8 +18,10 @@
 ;EXPORT_TAGS          = []
 # Export device configurations, when available
 ;EXPORT_CONFIGS       = true
-# Templates path
-;TEMPLATES_PATH       = ['templates']
+# Templates search path. Default path is ['./templates','$HOME/.nr/templates']. Env vars are supported
+;TEMPLATES_PATH       = ['./templates','$HOME/.nr/custom','$HOME/.nr/templates']
+# Platform map path. If not provided, 'platform_map.yaml' in the current directory is checked first, and then in the TEMPLATES_PATH folders. Env vars are supported
+;PLATFORM_MAP         = '$HOME/.nr/platform_map.yaml'
 # Levels of device roles for visualization
 [DEVICE_ROLE_LEVELS]
 ;unknown =              0

--- a/nrx/nrx.py
+++ b/nrx/nrx.py
@@ -27,7 +27,7 @@ nrx reads a network topology graph from NetBox DCIM system and exports it in one
 It can also read the topology graph previously saved as a CYJS file to convert it into the one of supported network emulation formats.
 """
 
-__version__ = 'v0.4.0-rc2'
+__version__ = 'v0.4.0-rc3'
 __author__ = 'Alex Bortok and Netreplica Team'
 
 import os
@@ -1158,6 +1158,12 @@ def load_toml_config(filename):
             error(f"Unable to parse configuration file {filename}: {e}")
         except argparse.ArgumentTypeError as e:
             error(f"Unsupported configuration: {e}")
+    path_config_keys = ['templates_path', 'platform_map', 'output_dir']
+    for k in path_config_keys:
+        if isinstance(config[k], str):
+            config[k] = os.path.expandvars(config[k])
+        elif isinstance(config[k], list):
+            config[k] = [os.path.expandvars(p) for p in config[k]]
     return config
 
 def config_apply_netbox_args(config, args):

--- a/tests/dc1/custom-clab/dc1.clab.yaml
+++ b/tests/dc1/custom-clab/dc1.clab.yaml
@@ -28,6 +28,7 @@ topology:
                 platform: Nokia SR-Linux
                 vendor: Nokia
                 model: 7220 IXR-D2
+
         dc1-spine-1:
             kind: linux
             image: frrouting/frr:latest
@@ -39,6 +40,7 @@ topology:
                 platform: Arista EOS
                 vendor: Arista
                 model: DCS-7280CR3-32P4
+
         dc1-spine-2:
             kind: linux
             image: frrouting/frr:latest
@@ -50,6 +52,7 @@ topology:
                 platform: Arista EOS
                 vendor: Arista
                 model: DCS-7280CR3-32P4
+
         dc1-leaf-2:
             kind: nokia_srlinux
             type: ixr6
@@ -62,6 +65,7 @@ topology:
                 platform: Nokia SR-Linux
                 vendor: Nokia
                 model: 7220 IXR-D2
+
         dc1-leaf-3:
             kind: nokia_srlinux
             type: ixr6
@@ -74,6 +78,7 @@ topology:
                 platform: Nokia SR-Linux
                 vendor: Nokia
                 model: 7220 IXR-D2
+
         dc1-leaf-4:
             kind: nokia_srlinux
             type: ixr6
@@ -86,6 +91,7 @@ topology:
                 platform: Nokia SR-Linux
                 vendor: Nokia
                 model: 7220 IXR-D2
+
         dc1-srv-1:
             kind: linux
             image: netreplica/ubuntu-host:1.4
@@ -100,6 +106,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
         dc1-srv-2:
             kind: linux
             image: netreplica/ubuntu-host:1.4
@@ -114,6 +121,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
         dc1-srv-3:
             kind: linux
             image: netreplica/ubuntu-host:1.4
@@ -128,6 +136,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
         dc1-srv-4:
             kind: linux
             image: netreplica/ubuntu-host:1.4
@@ -142,6 +151,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
     links:
         - endpoints: ["dc1-leaf-1:e1-49", "dc1-spine-1:eth1"]
         - endpoints: ["dc1-leaf-1:e1-50", "dc1-spine-2:eth1"]

--- a/tests/dc1/data/dc1.clab.yaml
+++ b/tests/dc1/data/dc1.clab.yaml
@@ -28,6 +28,7 @@ topology:
                 platform: Nokia SR-Linux
                 vendor: Nokia
                 model: 7220 IXR-D2
+
         dc1-spine-1:
             kind: ceos
             binds:
@@ -41,6 +42,7 @@ topology:
                 platform: Arista EOS
                 vendor: Arista
                 model: DCS-7280CR3-32P4
+
         dc1-spine-2:
             kind: ceos
             binds:
@@ -54,6 +56,7 @@ topology:
                 platform: Arista EOS
                 vendor: Arista
                 model: DCS-7280CR3-32P4
+
         dc1-leaf-2:
             kind: nokia_srlinux
             type: ixrd2
@@ -66,6 +69,7 @@ topology:
                 platform: Nokia SR-Linux
                 vendor: Nokia
                 model: 7220 IXR-D2
+
         dc1-leaf-3:
             kind: nokia_srlinux
             type: ixrd2
@@ -78,6 +82,7 @@ topology:
                 platform: Nokia SR-Linux
                 vendor: Nokia
                 model: 7220 IXR-D2
+
         dc1-leaf-4:
             kind: nokia_srlinux
             type: ixrd2
@@ -90,6 +95,7 @@ topology:
                 platform: Nokia SR-Linux
                 vendor: Nokia
                 model: 7220 IXR-D2
+
         dc1-srv-1:
             kind: linux
             image: netreplica/ubuntu-host:latest
@@ -104,6 +110,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
         dc1-srv-2:
             kind: linux
             image: netreplica/ubuntu-host:latest
@@ -118,6 +125,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
         dc1-srv-3:
             kind: linux
             image: netreplica/ubuntu-host:latest
@@ -132,6 +140,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
         dc1-srv-4:
             kind: linux
             image: netreplica/ubuntu-host:latest
@@ -146,6 +155,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
     links:
         - endpoints: ["dc1-leaf-1:e1-49", "dc1-spine-1:eth1"]
         - endpoints: ["dc1-leaf-1:e1-50", "dc1-spine-2:eth1"]

--- a/tests/h88/data/HQ.clab.yaml
+++ b/tests/h88/data/HQ.clab.yaml
@@ -27,6 +27,7 @@ topology:
                 platform: Cisco IOS-XE
                 vendor: Cisco
                 model: C9200-48P
+
         HQ-DistSw:
             kind: nokia_srlinux
             type: ixrd2
@@ -40,6 +41,7 @@ topology:
                 platform: Nokia SR-Linux
                 vendor: Nokia
                 model: 7220 IXR-D2
+
         HQ-Switch2:
             kind: ceos
             binds:
@@ -54,6 +56,7 @@ topology:
                 platform: Arista EOS
                 vendor: Arista
                 model: DCS-7010T-48
+
     links:
         - endpoints: ["HQ-Switch1:eth1", "HQ-DistSw:e1-1"]
         - endpoints: ["HQ-Switch1:eth2", "HQ-DistSw:e1-2"]

--- a/tests/site1/data/site1.clab.yaml
+++ b/tests/site1/data/site1.clab.yaml
@@ -27,6 +27,7 @@ topology:
                 platform: SONiC
                 vendor: Edgecore
                 model: 5912-54X-O-AC-F
+
         site1-h1:
             kind: linux
             image: netreplica/ubuntu-host:latest
@@ -41,6 +42,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
         site1-h2:
             kind: linux
             image: netreplica/ubuntu-host:latest
@@ -55,6 +57,7 @@ topology:
                 platform: Linux
                 vendor: Dell
                 model: PowerEdge R640
+
     links:
         - endpoints: ["site1-r1:eth1", "site1-h1:eth1"]
         - endpoints: ["site1-r1:eth2", "site1-h2:eth1"]

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,2 +1,2 @@
-nrx: v0.4.0-rc2
-templates: v0.2.0-rc2
+nrx: v0.4.0-rc3
+templates: v0.2.0-rc3


### PR DESCRIPTION
The following parameters in `nrx.conf` now supports ENV vars:

- TEMPLATES_PATH
- PLATFORM_MAP
- OUTPUT_DIR

This enables users to maintain custom maps and templates under a folder of their choice – be it `$HOME/.nr` or other place and make the configuration portable between different users.