### PR TITLE
Capability to filter links between devices via interface tags

### DIFF
--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,8 +1,8 @@
-name: Publish Python distribution to PyPI
+name: Publish Python distribution to TestPyPI
 
 on:
     push:
-        branches: [ "main" ]
+        branches: [ "dev" ]
     workflow_dispatch:
 
 jobs:
@@ -31,14 +31,14 @@ jobs:
                 path: dist/
 
     publish-to-pypi:
-        name: Publish to PyPI
+        name: Publish to TestPyPI
         needs:
           - build
         runs-on: ubuntu-latest
 
         environment:
-            name: release
-            url: https://pypi.org/p/nrx
+            name: devtest
+            url: https://test.pypi.org/p/nrx
 
         permissions:
             id-token: write  # IMPORTANT: mandatory for trusted publishing
@@ -49,5 +49,7 @@ jobs:
             with:
                 name: python-package-distributions
                 path: dist/
-          - name: Publish distribution to PyPI
+          - name: Publish distribution to TestPyPI
             uses: pypa/gh-action-pypi-publish@release/v1
+            with:
+              repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -3,6 +3,8 @@ name: Publish Python distribution to TestPyPI
 on:
     push:
         branches: [ "dev" ]
+    pull_request:
+        branches: [ "dev" ]
     workflow_dispatch:
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test-d2: test-dc1-cyjs-2-d2
 
 test-dc1: test-dc1-nb-2-cyjs-previous test-dc1-nb-2-cyjs-current test-dc1-nb-2-cyjs-latest test-dc1-cyjs-2-clab test-dc1-cyjs-2-clab-custom-platform-map test-dc1-cyjs-2-graphite test-dc1-cyjs-2-d2
 test-dc2: test-dc2-nb-2-cyjs-previous test-dc2-nb-2-cyjs-current test-dc2-nb-2-cyjs-latest test-dc2-cyjs-2-cml test-dc2-cyjs-2-graphite
-test-colo: test-colo-nb-2-cyjs-previous test-colo-nb-2-cyjs-current test-colo-nb-2-cyjs-latest
+test-colo: test-colo-nb-2-cyjs-previous test-colo-nb-2-cyjs-current test-colo-nb-2-cyjs-latest test-colo-nb-2-cyjs-interface-tags
 test-site1: test-site1-nb-2-cyjs-previous test-site1-nb-2-cyjs-current test-site1-nb-2-cyjs-latest test-site1-cyjs-2-clab test-site1-cyjs-2-clab-rename
 test-h88: test-h88-nb-2-cyjs-previous test-h88-nb-2-cyjs-current test-h88-nb-2-cyjs-latest test-h88-nb-2-cyjs-latest-noconfigs test-h88-cyjs-2-clab
 test-lrg: test-lrg-nb-2-cyjs-current test-lrg-nb-2-cyjs-latest test-lrg-cyjs-2-graphite
@@ -235,7 +235,17 @@ test-colo-nb-2-cyjs-latest:
 	mkdir -p tests/colo/test && cd tests/colo/test && rm -rf * && \
 	source ../../.env_latest && \
 	../../../nrx -c ../nrx.conf -o cyjs -d && \
-	diff colo.cyjs ../data/colo.cyjs
+	diff colo.cyjs ../data/colo-latest.cyjs
+	@echo
+
+test-colo-nb-2-cyjs-interface-tags:
+	@echo "#################################################################"
+	@echo "# Colo: read from NetBox latest version and export as CYJS using interface tags"
+	@echo "#################################################################"
+	mkdir -p tests/colo/test && cd tests/colo/test && rm -rf * && \
+	source ../../.env_latest && \
+	../../../nrx -c ../nrx.conf -o cyjs --interface-tags one,two,four -d && \
+	diff colo.cyjs ../data/colo-tags.cyjs
 	@echo
 
 test-site1-nb-2-cyjs-previous:

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ optional arguments:
   -s, --site SITE           netbox site to export, cannot be combined with --sites
       --sites SITES         netbox sites to export, for multiple tags use a comma-separated list: site1,site2,site3 (uses OR logic)
   -t, --tags TAGS           netbox tags to export, for multiple tags use a comma-separated list: tag1,tag2,tag3 (uses AND logic)
+      --interface-tags TAGS netbox tags to filter interfaces to export, for multiple tags use a comma-separated list: tag1,tag2,tag3 (uses OR logic)
   -n, --name NAME           name of the exported topology (site name or tags by default)
       --noconfigs           disable device configuration export (enabled by default)
   -k, --insecure            allow insecure server connections when using TLS

--- a/src/nrx/__about__.py
+++ b/src/nrx/__about__.py
@@ -19,4 +19,4 @@
 """
 Metadata for the nrx package
 """
-__version__ = "0.5.2"
+__version__ = "0.6.0rc0"

--- a/src/nrx/nrx.py
+++ b/src/nrx/nrx.py
@@ -305,7 +305,16 @@ class NBFactory:
                                                                          cabled=True,
                                                                          connected=True)):
                 if "base" in interface.type.value: # only ethernet interfaces
-                    debug(interface.device, ":", interface, ":", interface.type.value)
+                    if len(self.config['export_interface_tags']) > 0:
+                        tag_match = False
+                    for tag in interface.tags:
+                        if tag.name in self.config['export_interface_tags']: # implementing OR tag matching logic
+                            tag_match = True
+                            break
+                    if len(self.config['export_interface_tags']) > 0 and not tag_match:
+                        debug(f"{interface.device} : {interface} skipping, doesn't have any of the required tags")
+                        continue
+                    debug(f"{interface.device} : {interface} adding as {interface.type.value}")
                     i = {
                         "id": interface.id,
                         "type": "interface",
@@ -1014,6 +1023,9 @@ def parse_args():
                                                                           site1,site2,site3 (uses OR logic)')
     args_parser.add_argument('-t', '--tags',        required=False, help='netbox tags to export, for multiple tags use a comma-separated list: \
                                                                           tag1,tag2,tag3 (uses AND logic)')
+    args_parser.add_argument('--interface-tags',    required=False, help='netbox tags to filter interfaces to export, for multiple tags use a comma-separated list: \
+                                                                          tag1,tag2,tag3 (uses OR logic)',
+                                                                    metavar='TAGS')
     args_parser.add_argument('-n', '--name',        required=False, help='name of the exported topology (site name or tags by default)')
     args_parser.add_argument(      '--noconfigs',   required=False, help='disable device configuration export (enabled by default)',
                                                         action=argparse.BooleanOptionalAction)
@@ -1162,6 +1174,7 @@ def load_toml_config(filename):
         },
         'export_sites': [],
         'export_tags': [],
+        'export_interface_tags': [],
         'topology_name': '',
         'export_configs': True,
         'templates_path': ["./templates", f"{nrx_config_dir()}/templates"],
@@ -1212,6 +1225,9 @@ def config_apply_netbox_args(config, args):
     if args.tags is not None and len(args.tags) > 0:
         config['export_tags'] = args.tags.split(',')
         debug(f"List of tags to filter devices for export: {config['export_tags']}")
+    if args.interface_tags is not None and len(args.interface_tags) > 0:
+        config['export_interface_tags'] = args.interface_tags.split(',')
+        debug(f"List of tags to filter interfaces for export: {config['export_interface_tags']}")
     if len(config['export_sites']) == 0 and len(config['export_tags']) == 0:
         error("Need a Site name or Tags to export. Use --sites/--tags arguments, or EXPORT_SITE/EXPORT_TAGS key in --config file")
     if args.noconfigs is not None:

--- a/tests/colo/data/colo-latest.cyjs
+++ b/tests/colo/data/colo-latest.cyjs
@@ -1,0 +1,372 @@
+{
+    "data": [
+        [
+            "name",
+            "colo"
+        ]
+    ],
+    "directed": false,
+    "multigraph": false,
+    "elements": {
+        "nodes": [
+            {
+                "data": {
+                    "side": "a",
+                    "type": "device",
+                    "device": {
+                        "id": 35,
+                        "type": "device",
+                        "name": "sw1",
+                        "node_id": 0,
+                        "site": "colo",
+                        "platform": "eos",
+                        "platform_name": "Arista EOS",
+                        "vendor": "arista",
+                        "vendor_name": "Arista",
+                        "model": "ccs-720xp-24y6",
+                        "model_name": "CCS-720XP-24Y6",
+                        "role": "access-switch",
+                        "role_name": "Access Switch",
+                        "primary_ip4": "10.0.0.1/24",
+                        "primary_ip6": "",
+                        "config": "",
+                        "device_index": 0
+                    },
+                    "id": "0",
+                    "value": 0,
+                    "name": "0"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "device",
+                    "device": {
+                        "id": 36,
+                        "type": "device",
+                        "name": "sw2",
+                        "node_id": 1,
+                        "site": "colo",
+                        "platform": "eos",
+                        "platform_name": "Arista EOS",
+                        "vendor": "arista",
+                        "vendor_name": "Arista",
+                        "model": "ccs-720xp-24y6",
+                        "model_name": "CCS-720XP-24Y6",
+                        "role": "access-switch",
+                        "role_name": "Access Switch",
+                        "primary_ip4": "10.0.0.2/24",
+                        "primary_ip6": "",
+                        "config": "",
+                        "device_index": 1
+                    },
+                    "id": "1",
+                    "value": 1,
+                    "name": "1"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1181,
+                        "type": "interface",
+                        "name": "Ethernet1",
+                        "node_id": 2,
+                        "interface_index": 0
+                    },
+                    "id": "2",
+                    "value": 2,
+                    "name": "2"
+                }
+            },
+            {
+                "data": {
+                    "side": "a",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1212,
+                        "type": "interface",
+                        "name": "Ethernet1",
+                        "node_id": 9,
+                        "interface_index": 7
+                    },
+                    "id": "9",
+                    "value": 9,
+                    "name": "9"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1182,
+                        "type": "interface",
+                        "name": "Ethernet2",
+                        "node_id": 3,
+                        "interface_index": 1
+                    },
+                    "id": "3",
+                    "value": 3,
+                    "name": "3"
+                }
+            },
+            {
+                "data": {
+                    "side": "a",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1213,
+                        "type": "interface",
+                        "name": "Ethernet2",
+                        "node_id": 10,
+                        "interface_index": 8
+                    },
+                    "id": "10",
+                    "value": 10,
+                    "name": "10"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1183,
+                        "type": "interface",
+                        "name": "Ethernet3",
+                        "node_id": 4,
+                        "interface_index": 2
+                    },
+                    "id": "4",
+                    "value": 4,
+                    "name": "4"
+                }
+            },
+            {
+                "data": {
+                    "side": "a",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1214,
+                        "type": "interface",
+                        "name": "Ethernet3",
+                        "node_id": 11,
+                        "interface_index": 9
+                    },
+                    "id": "11",
+                    "value": 11,
+                    "name": "11"
+                }
+            },
+            {
+                "data": {
+                    "side": "a",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1184,
+                        "type": "interface",
+                        "name": "Ethernet4",
+                        "node_id": 5,
+                        "interface_index": 3
+                    },
+                    "id": "5",
+                    "value": 5,
+                    "name": "5"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1215,
+                        "type": "interface",
+                        "name": "Ethernet4",
+                        "node_id": 12,
+                        "interface_index": 10
+                    },
+                    "id": "12",
+                    "value": 12,
+                    "name": "12"
+                }
+            },
+            {
+                "data": {
+                    "side": "a",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1185,
+                        "type": "interface",
+                        "name": "Ethernet5",
+                        "node_id": 6,
+                        "interface_index": 4
+                    },
+                    "id": "6",
+                    "value": 6,
+                    "name": "6"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1216,
+                        "type": "interface",
+                        "name": "Ethernet5",
+                        "node_id": 13,
+                        "interface_index": 11
+                    },
+                    "id": "13",
+                    "value": 13,
+                    "name": "13"
+                }
+            },
+            {
+                "data": {
+                    "side": "a",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1186,
+                        "type": "interface",
+                        "name": "Ethernet6",
+                        "node_id": 7,
+                        "interface_index": 5
+                    },
+                    "id": "7",
+                    "value": 7,
+                    "name": "7"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1217,
+                        "type": "interface",
+                        "name": "Ethernet6",
+                        "node_id": 14,
+                        "interface_index": 12
+                    },
+                    "id": "14",
+                    "value": 14,
+                    "name": "14"
+                }
+            }
+        ],
+        "edges": [
+            {
+                "data": {
+                    "source": 0,
+                    "target": 2
+                }
+            },
+            {
+                "data": {
+                    "source": 0,
+                    "target": 3
+                }
+            },
+            {
+                "data": {
+                    "source": 0,
+                    "target": 4
+                }
+            },
+            {
+                "data": {
+                    "source": 0,
+                    "target": 5
+                }
+            },
+            {
+                "data": {
+                    "source": 0,
+                    "target": 6
+                }
+            },
+            {
+                "data": {
+                    "source": 0,
+                    "target": 7
+                }
+            },
+            {
+                "data": {
+                    "source": 1,
+                    "target": 9
+                }
+            },
+            {
+                "data": {
+                    "source": 1,
+                    "target": 10
+                }
+            },
+            {
+                "data": {
+                    "source": 1,
+                    "target": 11
+                }
+            },
+            {
+                "data": {
+                    "source": 1,
+                    "target": 12
+                }
+            },
+            {
+                "data": {
+                    "source": 1,
+                    "target": 13
+                }
+            },
+            {
+                "data": {
+                    "source": 1,
+                    "target": 14
+                }
+            },
+            {
+                "data": {
+                    "source": 2,
+                    "target": 9
+                }
+            },
+            {
+                "data": {
+                    "source": 3,
+                    "target": 10
+                }
+            },
+            {
+                "data": {
+                    "source": 4,
+                    "target": 11
+                }
+            },
+            {
+                "data": {
+                    "source": 5,
+                    "target": 12
+                }
+            },
+            {
+                "data": {
+                    "source": 6,
+                    "target": 13
+                }
+            },
+            {
+                "data": {
+                    "source": 7,
+                    "target": 14
+                }
+            }
+        ]
+    }
+}

--- a/tests/colo/data/colo-tags.cyjs
+++ b/tests/colo/data/colo-tags.cyjs
@@ -1,0 +1,172 @@
+{
+    "data": [
+        [
+            "name",
+            "colo"
+        ]
+    ],
+    "directed": false,
+    "multigraph": false,
+    "elements": {
+        "nodes": [
+            {
+                "data": {
+                    "side": "a",
+                    "type": "device",
+                    "device": {
+                        "id": 35,
+                        "type": "device",
+                        "name": "sw1",
+                        "node_id": 0,
+                        "site": "colo",
+                        "platform": "eos",
+                        "platform_name": "Arista EOS",
+                        "vendor": "arista",
+                        "vendor_name": "Arista",
+                        "model": "ccs-720xp-24y6",
+                        "model_name": "CCS-720XP-24Y6",
+                        "role": "access-switch",
+                        "role_name": "Access Switch",
+                        "primary_ip4": "10.0.0.1/24",
+                        "primary_ip6": "",
+                        "config": "",
+                        "device_index": 0
+                    },
+                    "id": "0",
+                    "value": 0,
+                    "name": "0"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "device",
+                    "device": {
+                        "id": 36,
+                        "type": "device",
+                        "name": "sw2",
+                        "node_id": 1,
+                        "site": "colo",
+                        "platform": "eos",
+                        "platform_name": "Arista EOS",
+                        "vendor": "arista",
+                        "vendor_name": "Arista",
+                        "model": "ccs-720xp-24y6",
+                        "model_name": "CCS-720XP-24Y6",
+                        "role": "access-switch",
+                        "role_name": "Access Switch",
+                        "primary_ip4": "10.0.0.2/24",
+                        "primary_ip6": "",
+                        "config": "",
+                        "device_index": 1
+                    },
+                    "id": "1",
+                    "value": 1,
+                    "name": "1"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1181,
+                        "type": "interface",
+                        "name": "Ethernet1",
+                        "node_id": 2,
+                        "interface_index": 0
+                    },
+                    "id": "2",
+                    "value": 2,
+                    "name": "2"
+                }
+            },
+            {
+                "data": {
+                    "side": "a",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1212,
+                        "type": "interface",
+                        "name": "Ethernet1",
+                        "node_id": 5,
+                        "interface_index": 3
+                    },
+                    "id": "5",
+                    "value": 5,
+                    "name": "5"
+                }
+            },
+            {
+                "data": {
+                    "side": "b",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1182,
+                        "type": "interface",
+                        "name": "Ethernet2",
+                        "node_id": 3,
+                        "interface_index": 1
+                    },
+                    "id": "3",
+                    "value": 3,
+                    "name": "3"
+                }
+            },
+            {
+                "data": {
+                    "side": "a",
+                    "type": "interface",
+                    "interface": {
+                        "id": 1213,
+                        "type": "interface",
+                        "name": "Ethernet2",
+                        "node_id": 6,
+                        "interface_index": 4
+                    },
+                    "id": "6",
+                    "value": 6,
+                    "name": "6"
+                }
+            }
+        ],
+        "edges": [
+            {
+                "data": {
+                    "source": 0,
+                    "target": 2
+                }
+            },
+            {
+                "data": {
+                    "source": 0,
+                    "target": 3
+                }
+            },
+            {
+                "data": {
+                    "source": 1,
+                    "target": 5
+                }
+            },
+            {
+                "data": {
+                    "source": 1,
+                    "target": 6
+                }
+            },
+            {
+                "data": {
+                    "source": 2,
+                    "target": 5
+                }
+            },
+            {
+                "data": {
+                    "source": 3,
+                    "target": 6
+                }
+            }
+        ]
+    }
+}

--- a/tests/colo/import/nb_00_tags.csv
+++ b/tests/colo/import/nb_00_tags.csv
@@ -1,0 +1,10 @@
+name,slug,color
+wan,wan,2196f3
+primary,primary,4caf50
+backup,backup,607d8b
+one,one,ff5722
+two,two,ff9800
+three,three,ffeb3b
+four,four,ffc107
+five,five,ff9800
+six,six,ff5722

--- a/tests/colo/import/nb_06_cables.csv
+++ b/tests/colo/import/nb_06_cables.csv
@@ -27,3 +27,6 @@ sw1,dcim.interface,Ethernet1,pp1,dcim.frontport,Port 1
 sw1,dcim.interface,Ethernet2,pp1,dcim.frontport,Port 2
 sw2,dcim.interface,Ethernet1,pp2,dcim.frontport,Port 1
 sw2,dcim.interface,Ethernet2,pp2,dcim.frontport,Port 2
+sw1,dcim.interface,Ethernet4,sw2,dcim.interface,Ethernet4
+sw1,dcim.interface,Ethernet5,sw2,dcim.interface,Ethernet5
+sw1,dcim.interface,Ethernet6,sw2,dcim.interface,Ethernet6

--- a/tests/colo/import/nb_10_tags.csv
+++ b/tests/colo/import/nb_10_tags.csv
@@ -1,4 +1,0 @@
-name,slug,color
-wan,wan,2196f3
-primary,primary,4caf50
-backup,backup,607d8b

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,2 +1,2 @@
-nrx: v0.5.2
+nrx: v0.6.0rc0
 templates: v0.2.0


### PR DESCRIPTION
Added capability to filter links between devices by using tags on the interface level. Note, both sides of each link to export should be tagged.

```
--interface-tags TAGS netbox tags to filter interfaces to export, for multiple tags use a comma-separated list: tag1,tag2,tag3 (uses OR logic)
```