### PR TITLE
testpypi only on PR to main

### DIFF
--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,10 +1,8 @@
 name: Publish Python distribution to TestPyPI
 
 on:
-    push:
-        branches: [ "dev" ]
     pull_request:
-        branches: [ "dev" ]
+        branches: [ "main" ]
     workflow_dispatch:
 
 jobs:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-disable=C0103,C0301,R0903,C0116,W0603,W0718
+disable=C0103,C0301,R0903,C0116,W0603,W0718,R0917
 [DESIGN]
 # needed to match number of arguments in requests.send
 max-args=7

--- a/src/nrx/__about__.py
+++ b/src/nrx/__about__.py
@@ -19,4 +19,4 @@
 """
 Metadata for the nrx package
 """
-__version__ = "0.6.1"
+__version__ = "0.7.0rc0"

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,2 +1,2 @@
-nrx: v0.6.1
+nrx: v0.7.0-rc0
 templates: v0.2.0


### PR DESCRIPTION
Publish to testpypi only on PR to main to avoid failing tests due to version conflict